### PR TITLE
Speed up pre-push; fix Docker resource naming

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,7 @@
 #!/bin/sh
-# Pre-push hook that runs tests before pushing
+# Pre-push hook that runs tests before pushing (fast + robust)
+set -euo pipefail
+trap 'echo; echo "❌ Aborted"; exit 130' INT TERM
 
 echo "🚀 Running tests before push..."
 echo ""
@@ -20,11 +22,16 @@ else
     NEEDS_BUILD=1
 fi
 
-# Export build decision for Makefile
+# Export build decision for Makefile / scripts
 export DOCKER_BUILD_NEEDED=$NEEDS_BUILD
 export DOCKER_BUILD_CHECKSUM=$CURRENT_CHECKSUM
 export DOCKER_BUILD_CHECKSUM_FILE=$LAST_BUILD_FILE
 export OPTIMIZE_FLAGS=""
+# Speed up local pushes: skip full docker build step in scripts/test.sh
+export SKIP_DOCKER_BUILD=1
+
+# Non-interactive test environment
+export CI=1
 
 # Run tests (which includes all CI checks)
 npm test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: image-dump
+
 services:
   # Linting service
   lint:
@@ -5,6 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: development
+    image: image-dump/lint:dev
     volumes:
       - ./scripts:/app/scripts${LINT_MOUNT_MODE:-:ro}
       - ./src:/app/src${LINT_MOUNT_MODE:-:ro}
@@ -19,6 +22,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: production
+    image: image-dump/optimize:prod
     volumes:
       - ./original:/app/original:ro
       - ./optimized:/app/optimized
@@ -37,6 +41,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: development
+    image: image-dump/test:dev
     volumes:
       - ./scripts:/app/scripts${TEST_MOUNT_MODE:-:ro}
       - ./src:/app/src${TEST_MOUNT_MODE:-:ro}
@@ -71,13 +76,19 @@ services:
 
   test-coverage:
     extends: test
+    image: image-dump/test-coverage:dev
     environment:
       - TEST_COMMAND=_docker:test:coverage
       - NODE_ENV=test
 
   test-watch:
     extends: test
+    image: image-dump/test-watch:dev
     environment:
       - TEST_COMMAND=_docker:test:watch
       - TEST_MOUNT_MODE=  # Empty means read-write for watch mode
       - NODE_ENV=test
+
+networks:
+  default:
+    name: image-dump_net

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -27,8 +27,14 @@ echo "2️⃣ Running tests with coverage..."
 docker compose run --rm -T test-coverage
 
 echo ""
-echo "3️⃣ Building all Docker services..."
-docker compose build
+if [ "${SKIP_DOCKER_BUILD:-0}" = "1" ]; then
+    echo "⏭️  Skipping Docker build (SKIP_DOCKER_BUILD=1)."
+elif [ "${DOCKER_BUILD_NEEDED:-0}" = "1" ]; then
+    echo "3️⃣ Building all Docker services..."
+    docker compose build
+else
+    echo "✅ Using cached Docker images (no source changes detected)"
+fi
 
 echo ""
 echo "✅ All checks passed!"


### PR DESCRIPTION
This PR improves the local pre-push experience and prevents Docker resource sprawl.

Changes
- Pre-push speed and behavior
  - .githooks/pre-push: add set -euo pipefail + clean SIGINT/SIGTERM trap
  - Export SKIP_DOCKER_BUILD=1 and CI=1 so scripts/test.sh won’t run the heavy compose build locally, and aborts cleanly
  - scripts/test.sh: only build services when DOCKER_BUILD_NEEDED=1; otherwise skip
- Fixed Docker resource naming
  - docker-compose.yml: set project name (name: image-dump)
  - Assign stable image tags for services (image-dump/*:dev, image-dump/optimize:prod)
  - Set a fixed default network name (image-dump_net)

Why
- Avoid the apparent “hang” after tests: the old hook always rebuilt every service image
- Ctrl+C now aborts the hook cleanly on first press
- Prevent accumulation of anonymous images/networks/volumes across runs

Notes
- CI can still run full builds and coverage
- Local pushes still run the full test suite with coverage, but skip the final build step