### PR TITLE
Periodic resume checkpoints during parallel processing

### DIFF
--- a/docs/modules/error-recovery-manager.md
+++ b/docs/modules/error-recovery-manager.md
@@ -17,6 +17,7 @@ class ErrorRecoveryManager {
   constructor(options = {})
   
   async processWithRecovery(operation, context)
+  async maybeCheckpoint(context)
   async saveState(state)
   async loadState()
   async clearState()
@@ -176,6 +177,21 @@ Initializes the ErrorRecoveryManager with configuration options.
   - `stateFile` (string): Path to state persistence file
   - `errorLog` (string): Path to error log file
   - `logger` (Object): Logger interface (default: console)
+  - `checkpointEveryN` (number): Save a checkpoint every N processed files (default: 5)
+  - `checkpointIntervalMs` (number): Minimum time between checkpoints in ms; set 0 to disable time throttling (default: 2000)
+
+### maybeCheckpoint(context)
+
+Throttled checkpoint that persists progress mid-run.
+
+Checks both a count threshold and an optional time threshold, and writes a lightweight snapshot via `StatePersistenceManager.save(...)`. When `checkpointEveryN` is 0, the count threshold is disabled; when `checkpointIntervalMs` is 0, the time throttle is disabled. A simple internal mutex prevents concurrent writes in parallel contexts.
+
+**Parameters**:
+- `context` (Object): `{ total?: number }` total files in the current batch.
+
+**Behavior**:
+- Saves `progress` (total, processed, succeeded, failed, remaining) and the list of processed files (path + status).
+- Resets the internal count and updates the last-checkpoint timestamp on success.
 
 ### processWithRecovery(operation, context)
 

--- a/src/error-recovery-manager.js
+++ b/src/error-recovery-manager.js
@@ -169,11 +169,13 @@ class ErrorRecoveryManager {
     const now = Date.now();
     const processed = this.processedFiles.size;
 
-    const byCount = this._sinceLastCheckpointCount >= Math.max(1, this.checkpointEveryN);
-    const byTime = (now - this._lastCheckpointTime) >= Math.max(0, this.checkpointIntervalMs);
+    const countEnabled = (this.checkpointEveryN || 0) > 0;
+    const timeEnabled = (this.checkpointIntervalMs || 0) > 0;
+    const countReady = !countEnabled || this._sinceLastCheckpointCount >= this.checkpointEveryN;
+    const timeReady = !timeEnabled || (now - this._lastCheckpointTime) >= this.checkpointIntervalMs;
 
-    if (!byCount && !byTime) {
-      return; // nothing to do
+    if (!(countReady && timeReady)) {
+      return; // nothing to do yet
     }
 
     if (this._checkpointMutex) {

--- a/src/error-recovery-manager.js
+++ b/src/error-recovery-manager.js
@@ -164,7 +164,52 @@ class ErrorRecoveryManager {
 
   // Structure: throttled checkpoint (implementation added in behavior commit)
   async maybeCheckpoint(_context = {}) {
-    // placeholder; behavior implemented in subsequent commit
+    const total = _context.total || _context.totalCount || _context.totalFiles || 0;
+
+    const now = Date.now();
+    const processed = this.processedFiles.size;
+
+    const byCount = this._sinceLastCheckpointCount >= Math.max(1, this.checkpointEveryN);
+    const byTime = (now - this._lastCheckpointTime) >= Math.max(0, this.checkpointIntervalMs);
+
+    if (!byCount && !byTime) {
+      return; // nothing to do
+    }
+
+    if (this._checkpointMutex) {
+      return; // another checkpoint in flight
+    }
+
+    this._checkpointMutex = true;
+    try {
+      // Build a lightweight state snapshot
+      const processedArray = Array.from(this.processedFiles.entries()).map(([p, data]) => ({ path: p, ...data }));
+      const succeeded = processedArray.filter(f => f.status === 'processed' || f.status === 'success').length;
+      const failed = processedArray.filter(f => f.status === 'error' || f.status === 'failed').length;
+
+      const snapshot = {
+        startedAt: new Date().toISOString(),
+        total,
+        configuration: {},
+        progress: {
+          total,
+          processed,
+          succeeded,
+          failed,
+          remaining: total > 0 ? Math.max(0, total - processed) : 0
+        },
+        files: {
+          processed: processedArray,
+          pending: []
+        }
+      };
+
+      await this.statePersistence.save(snapshot);
+      this._lastCheckpointTime = now;
+      this._sinceLastCheckpointCount = 0;
+    } finally {
+      this._checkpointMutex = false;
+    }
   }
 }
 

--- a/src/error-recovery-manager.js
+++ b/src/error-recovery-manager.js
@@ -9,6 +9,12 @@ class ErrorRecoveryManager {
     this.exponentialBackoff = options.exponentialBackoff !== false;
     this.processedFiles = new Map();
     this.logger = options.logger || console;
+    // Periodic checkpoint configuration
+    this.checkpointEveryN = options.checkpointEveryN || 5;
+    this.checkpointIntervalMs = options.checkpointIntervalMs || 2000;
+    this._lastCheckpointTime = 0;
+    this._sinceLastCheckpointCount = 0;
+    this._checkpointMutex = false;
     
     // Delegate state persistence and error logging
     this.statePersistence = new StatePersistenceManager({
@@ -110,6 +116,7 @@ class ErrorRecoveryManager {
 
   recordProcessedFile(filePath, result) {
     this.processedFiles.set(filePath, result);
+    this._sinceLastCheckpointCount++;
   }
 
   isFileProcessed(filePath) {
@@ -153,6 +160,11 @@ class ErrorRecoveryManager {
 
   sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  // Structure: throttled checkpoint (implementation added in behavior commit)
+  async maybeCheckpoint(_context = {}) {
+    // placeholder; behavior implemented in subsequent commit
   }
 }
 

--- a/src/image-optimizer-app.js
+++ b/src/image-optimizer-app.js
@@ -87,10 +87,12 @@ class ImageOptimizerApp {
               }
   
               this.errorRecoveryManager.recordProcessedFile(file, { status: result });
+              await this.errorRecoveryManager.maybeCheckpoint({ total: imageFiles.length });
             } catch (error) {
               stats.errors++;
               this.progressManager.increment({ status: 'error', filename: file });
               await this.errorRecoveryManager.logError(file, error, { type: 'processing_error' });
+              await this.errorRecoveryManager.maybeCheckpoint({ total: imageFiles.length });
               if (!continueOnError) {throw error;}
             }
           }

--- a/tests/lib/error-recovery-manager.test.js
+++ b/tests/lib/error-recovery-manager.test.js
@@ -186,6 +186,52 @@ describe('ErrorRecoveryManager', () => {
       exists = await fs.access(errorManager.stateFile).then(() => true).catch(() => false);
       expect(exists).toBe(false);
     });
+
+    it('should periodically checkpoint by count', async () => {
+      // Arrange a manager with tiny checkpoint thresholds
+      errorManager.checkpointEveryN = 2;
+      errorManager.checkpointIntervalMs = 0;
+      // Point state file to tempDir for isolation
+      errorManager.statePersistence.stateFile = path.join(tempDir, 'checkpoint-state.json');
+
+      // Act: record 2 files and call maybeCheckpoint after each
+      errorManager.recordProcessedFile('a.png', { status: 'success' });
+      await errorManager.maybeCheckpoint({ total: 5 });
+      let exists = await fs.access(errorManager.stateFile).then(() => true).catch(() => false);
+      expect(exists).toBe(false); // not enough yet
+
+      errorManager.recordProcessedFile('b.png', { status: 'success' });
+      await errorManager.maybeCheckpoint({ total: 5 });
+      exists = await fs.access(errorManager.stateFile).then(() => true).catch(() => false);
+      expect(exists).toBe(true); // checkpoint written at 2 files
+
+      // Verify saved state has processed count
+      const saved = JSON.parse(await fs.readFile(errorManager.stateFile, 'utf8'));
+      expect(saved.progress.processed).toBe(2);
+    });
+
+    it('should throttle checkpoints by time', async () => {
+      errorManager.checkpointEveryN = 1; // allow by count
+      errorManager.checkpointIntervalMs = 100; // throttle by time
+      errorManager.statePersistence.stateFile = path.join(tempDir, 'checkpoint-throttle.json');
+
+      errorManager.recordProcessedFile('x.png', { status: 'success' });
+      await errorManager.maybeCheckpoint({ total: 2 });
+      const first = JSON.parse(await fs.readFile(errorManager.stateFile, 'utf8'));
+      expect(first.progress.processed).toBe(1);
+
+      // Immediately try again; should be throttled and not overwrite processed count 1 -> still 1
+      errorManager.recordProcessedFile('y.png', { status: 'success' });
+      await errorManager.maybeCheckpoint({ total: 2 });
+      const after = JSON.parse(await fs.readFile(errorManager.stateFile, 'utf8'));
+      expect(after.progress.processed).toBe(1);
+
+      // Wait past interval and checkpoint again
+      await new Promise(r => setTimeout(r, 110));
+      await errorManager.maybeCheckpoint({ total: 2 });
+      const final = JSON.parse(await fs.readFile(errorManager.stateFile, 'utf8'));
+      expect(final.progress.processed).toBe(2);
+    });
   });
   
   describe('report generation', () => {


### PR DESCRIPTION
Implements periodic state checkpointing so --resume works mid-batch.\n\n- ErrorRecoveryManager: adds maybeCheckpoint with count + time throttles and a simple mutex.\n- ImageOptimizerApp: calls maybeCheckpoint after each file processed/error inside worker loop.\n- Tests: new unit tests for checkpoint-by-count and time throttle.\n- Docs: updated ErrorRecoveryManager docs for options + API.\n\nThis addresses #10.