### PR TITLE
Docs + CLI: checkpoint flags and resume docs

### DIFF
--- a/.imagerc.example
+++ b/.imagerc.example
@@ -35,7 +35,9 @@
 //   "maxRetries": 3,              // Retry attempts for transient errors
 //   "retryDelay": 1000,           // Initial retry delay (ms)
 //   "exponentialBackoff": true,   // Use exponential backoff
-//   "errorLog": "errors.log"      // Custom error log path
+//   "errorLog": "errors.log",     // Custom error log path
+//   "checkpointEveryN": 5,         // Save a checkpoint every N files (0 disables count trigger)
+//   "checkpointIntervalMs": 2000   // Minimum ms between checkpoints (0 disables time throttle)
 // }
 //
 // Per-image quality rules:

--- a/README.md
+++ b/README.md
@@ -159,11 +159,35 @@ npm run optimize -- --quiet
 
 # Custom config file
 npm run optimize -- --config=production.imagerc
+
+# One-off checkpoint tuning (overrides .imagerc)
+# Save a checkpoint after every N files (0 disables count trigger)
+npm run optimize -- --checkpoint-every=5
+# Minimum milliseconds between checkpoints (0 disables time throttle)
+npm run optimize -- --checkpoint-interval-ms=2000
 ```
 
 ## Cache Manifest
 
 Each optimization run maintains an `optimized/.image-manifest.json` file that records the SHA-256 digest of every cooked source image and the outputs that were generated. The manifest allows the optimizer to skip work reliably—even if timestamps change—and doubles as a quick audit log of what was produced. Commit it alongside your optimized assets, or delete it to force a full rebuild on the next run.
+
+### Resuming Runs and Checkpoints
+
+Long runs periodically save progress to `.image-optimization-state.json`. If a batch is interrupted (e.g., machine reboot or Ctrl+C), rerun with `--resume` to continue from the last checkpoint.
+
+Tune checkpoint behavior via `.imagerc`:
+
+```jsonc
+{
+  "errorRecovery": {
+    "continueOnError": true,
+    "checkpointEveryN": 5,        // Save after every 5 files (0 disables count trigger)
+    "checkpointIntervalMs": 2000  // Minimum ms between checkpoints (0 disables time throttle)
+  }
+}
+```
+
+Use CLI flags to override for a one-off run: `--checkpoint-every=` and `--checkpoint-interval-ms=`.
 
 ## GitHub Actions
 

--- a/scripts/optimize-images.js
+++ b/scripts/optimize-images.js
@@ -47,7 +47,9 @@ async function main() {
       retryDelay: config.errorRecovery?.retryDelay || options.retryDelay,
       exponentialBackoff: config.errorRecovery?.exponentialBackoff !== false,
       errorLog: config.errorRecovery?.errorLog || options.errorLog,
-      resume: options.resumeFlag
+      resume: options.resumeFlag,
+      checkpointEveryN: options.checkpointEveryN !== undefined ? options.checkpointEveryN : config.errorRecovery?.checkpointEveryN,
+      checkpointIntervalMs: options.checkpointIntervalMs !== undefined ? options.checkpointIntervalMs : config.errorRecovery?.checkpointIntervalMs
     });
     
     // Create quality rules engine

--- a/src/cli-parser.js
+++ b/src/cli-parser.js
@@ -14,7 +14,9 @@ class CliParser {
       watchMode: this.hasFlag('--watch'),
       maxRetries: this.getIntValue('--max-retries=', 3),
       retryDelay: this.getIntValue('--retry-delay=', 1000),
-      errorLog: this.getStringValue('--error-log=', 'image-optimization-errors.log')
+      errorLog: this.getStringValue('--error-log=', 'image-optimization-errors.log'),
+      checkpointEveryN: this.getIntValue('--checkpoint-every=', undefined),
+      checkpointIntervalMs: this.getIntValue('--checkpoint-interval-ms=', undefined)
     };
 
     const selectedFilesValue = this.getStringValue('--files=', '');
@@ -34,7 +36,9 @@ class CliParser {
 
   getIntValue(prefix, defaultValue) {
     const arg = this.args.find(arg => arg.startsWith(prefix));
-    return arg ? parseInt(arg.split('=')[1]) : defaultValue;
+    if (!arg) { return defaultValue; }
+    const val = parseInt(arg.split('=')[1]);
+    return Number.isNaN(val) ? defaultValue : val;
   }
 
   getStringValue(prefix, defaultValue) {

--- a/tests/lib/cli-parser.test.js
+++ b/tests/lib/cli-parser.test.js
@@ -1,0 +1,19 @@
+const CliParser = require('../../src/cli-parser');
+
+describe('CliParser checkpoint flags', () => {
+  it('parses --checkpoint-every and --checkpoint-interval-ms as integers', () => {
+    const args = ['--checkpoint-every=7', '--checkpoint-interval-ms=1500'];
+    const parser = new CliParser(args);
+    const opts = parser.parse();
+    expect(opts.checkpointEveryN).toBe(7);
+    expect(opts.checkpointIntervalMs).toBe(1500);
+  });
+
+  it('ignores invalid integers and leaves undefined', () => {
+    const args = ['--checkpoint-every=abc'];
+    const parser = new CliParser(args);
+    const opts = parser.parse();
+    expect(opts.checkpointEveryN).toBeUndefined();
+  });
+});
+


### PR DESCRIPTION
Adds --checkpoint-every and --checkpoint-interval-ms; documents checkpointing and resume in README; updates .imagerc.example.